### PR TITLE
Updating 404 page to base _blank for external iframes

### DIFF
--- a/404.html
+++ b/404.html
@@ -139,7 +139,7 @@
   
 <body class="home home-1 has-block-heading-line">
 
-
+    <base target="_blank" />
 
 <!-- .site-wrapper -->
 <div class="site-wrapper" >


### PR DESCRIPTION
This was the only possible workaround to external iframe <base> elements not being supported on GH Pages, as we don't have access to the origin-origin server. It should work, but now links will open in a new (not parent) window even when on the internal page itself (not cross-origin or cross-domain).